### PR TITLE
AppContainer and PageContainer 

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background-color: #282c34;
+  background-color: #282c34 !important;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom'
-import './index.css';
-import App from './modules/app/App';
-import * as serviceWorkerRegistration from './setup/serviceWorkerRegistration';
-import reportWebVitals from './setup/reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
+import "./index.css";
+import App from "./modules/app/App";
+import * as serviceWorkerRegistration from "./setup/serviceWorkerRegistration";
+import reportWebVitals from "./setup/reportWebVitals";
 
 ReactDOM.render(
   <BrowserRouter basename={process.env.PUBLIC_URL}>
     <App />
   </BrowserRouter>,
- document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/modules/App/App.js
+++ b/src/modules/App/App.js
@@ -9,6 +9,7 @@ import Header from "../common/header/Header";
 import Error400 from "../common/error/Error400";
 import Error500 from "../common/error/Error500";
 import { ErrorBoundary } from "react-error-boundary";
+import AppContainer from "../../ui/containers/AppContainer";
 
 function App() {
   const [state, dispatch] = useReducer(appReducer, initialState);
@@ -17,7 +18,7 @@ function App() {
     <ErrorBoundary FallbackComponent={Error500}>
       <AppContext.Provider value={[state, dispatch]}>
         <Header />
-        {/* <Sidebar /> */}
+        <AppContainer />
         <Switch>
           <Route exact path="/daily-mission" component={DailyMission} />
           <Route exact path="/style-guide" component={StyleSample} />

--- a/src/modules/App/App.js
+++ b/src/modules/App/App.js
@@ -18,7 +18,14 @@ function App() {
       <AppContext.Provider value={[state, dispatch]}>
         <AppContainer />
         <Switch>
-          <Route exact path="/daily-mission" component={DailyMission} />
+          <Route
+            exact
+            path="/daily-mission/:id"
+            render={({ match }) => {
+              const id = +match.params.id;
+              return <DailyMission id={id} />;
+            }}
+          />
           <Route exact path="/style-guide" component={StyleSample} />
           <Route exact path="/mission-control" component={MissionControl} />
           <Route exact path="/error-500" component={Error500} />

--- a/src/modules/App/App.js
+++ b/src/modules/App/App.js
@@ -5,7 +5,6 @@ import { appReducer, initialState } from "../common/appReducer";
 import MissionControl from "../views/MissionControl";
 import StyleSample from "../views/StyleSample";
 import DailyMission from "../views/DailyMission";
-import Header from "../common/header/Header";
 import Error400 from "../common/error/Error400";
 import Error500 from "../common/error/Error500";
 import { ErrorBoundary } from "react-error-boundary";
@@ -17,7 +16,6 @@ function App() {
   return (
     <ErrorBoundary FallbackComponent={Error500}>
       <AppContext.Provider value={[state, dispatch]}>
-        <Header />
         <AppContainer />
         <Switch>
           <Route exact path="/daily-mission" component={DailyMission} />

--- a/src/modules/App/App.js
+++ b/src/modules/App/App.js
@@ -5,7 +5,6 @@ import { appReducer, initialState } from "../common/appReducer";
 import MissionControl from "../views/MissionControl";
 import StyleSample from "../views/StyleSample";
 import DailyMission from "../views/DailyMission";
-import Sidebar from "../common/sidebar/Sidebar";
 import Header from "../common/header/Header";
 import Error400 from "../common/error/Error400";
 import Error500 from "../common/error/Error500";
@@ -13,7 +12,7 @@ import { ErrorBoundary } from "react-error-boundary";
 
 function App() {
   const [state, dispatch] = useReducer(appReducer, initialState);
-  
+
   return (
     <ErrorBoundary FallbackComponent={Error500}>
       <AppContext.Provider value={[state, dispatch]}>

--- a/src/modules/common/header/Header.jsx
+++ b/src/modules/common/header/Header.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import Button from "../../../ui/button/Button";
 import { Link } from "react-router-dom";
-import { makeStyles } from "@material-ui/core";
-import * as colors from '../../../ui/common/colors'
+import { makeStyles, useTheme } from "@material-ui/core";
 
-const useStyles = makeStyles(primary => ({
+import * as colors from '../../../ui/common/colors'
+const drawerWidth = 240;
+const useStyles = makeStyles((theme) => ({
   navbar: {
     background: "rebeccapurple",
     display: "flex",
@@ -30,7 +31,7 @@ const Header = () => {
   return (
     <header className={classes.navbar}>
       <section className={classes.left}>
-        <h1>BRANDING + NAVBAR</h1>
+        <h1>BRANDING + NAV FOR DEVELOPMENT</h1>
       </section>
       <nav className={classes.linkContainer}>
         <Link className={classes} title="mission control" to="/mission-control">

--- a/src/modules/common/sidebar/Sidebar.jsx
+++ b/src/modules/common/sidebar/Sidebar.jsx
@@ -1,38 +1,29 @@
-// const Sidebar = () => {
-//   return (
-//     <aside>
-      // <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
-//     </aside>
-//   )
-// }
-
-// export default Sidebar
-import React, { createContext, useContext } from 'react';
+// React Imports
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+
+// Material-ui Imports
 import AppBar from '@material-ui/core/AppBar';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Divider from '@material-ui/core/Divider';
 import Drawer from '@material-ui/core/Drawer';
 import Hidden from '@material-ui/core/Hidden';
 import IconButton from '@material-ui/core/IconButton';
-// import InboxIcon from '@material-ui/icons/MoveToInbox';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-// import  from '@material-ui/core/';
-import ListItemText from '@material-ui/core/ListItemText';
-
 import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 
 // App Imports
-import AppContext from "../../app/AppContext";
+// import AppContext from "../../app/AppContext";
+import theme from "../../../ui/common/theme"
 
-
-
+const appStyles = theme
 const drawerWidth = 240;
 
+
 const useStyles = makeStyles((theme) => ({
+  
   root: {
     display: 'flex',
   },
@@ -43,6 +34,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   appBar: {
+    backgroundColor: appStyles.colors.primary,
     [theme.breakpoints.up('sm')]: {
       width: `calc(100% - ${drawerWidth}px)`,
       marginLeft: drawerWidth,
@@ -55,10 +47,11 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   // necessary for content to be below app bar
-  toolbar: theme.mixins.toolbar,
+  // toolbar: theme.mixins.toolbar,
   drawerPaper: {
     width: drawerWidth,
-    backgroundColor: '#EA5455'
+    backgroundColor: appStyles.colors.primary
+
   },
   content: {
     flexGrow: 1,
@@ -67,10 +60,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function SideBar(props) {
-
-  const [state, dispatch] = useContext(AppContext)
+  // const [state, dispatch] = useContext(AppContext)
   const { window } = props;
-  
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -78,18 +69,19 @@ function SideBar(props) {
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
-console.log(state)
+
   const drawer = (
-    <div style={{backgroundColor:`${state.theme.colors.primary}`}}>
-      <div className={classes.toolbar} />
-      <List>
-
-          <ListItem button >
-            <>⭐</>
-            <ListItemText />
-          </ListItem>
-
-      </List>
+    <div>
+      <Toolbar className={classes.toolbar}>AGENT DETAILS</Toolbar>
+      <Divider/>
+      <div className={classes.drawerPaper} />
+        {/* <Toolbar> */}
+      
+              {/* <div className={classes.drawerPaper}> */}
+                <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
+              {/* </div> */}
+          
+      {/* </Toolbar> */}
     </div>
   );
 
@@ -98,7 +90,7 @@ console.log(state)
   return (
     <div className={classes.root}>
       <CssBaseline />
-      <AppBar style={{backgroundColor:`${state.theme.colors.primary}`}} position="fixed" className={classes.appBar}>
+      {/* <AppBar  position="fixed" className={classes.appBar}> */}
         <Toolbar>
           <IconButton
             color="inherit"
@@ -110,7 +102,7 @@ console.log(state)
           ⭐
           </IconButton>
         </Toolbar>
-      </AppBar>
+      {/* </AppBar> */}
       <nav className={classes.drawer} aria-label="agent-profile">
         <Hidden smUp implementation="css">
           <Drawer
@@ -127,7 +119,6 @@ console.log(state)
             }}
           >
             {drawer}
-             <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
           </Drawer>
         </Hidden>
         <Hidden xsDown implementation="css">

--- a/src/modules/common/sidebar/Sidebar.jsx
+++ b/src/modules/common/sidebar/Sidebar.jsx
@@ -1,9 +1,153 @@
-const Sidebar = () => {
+// const Sidebar = () => {
+//   return (
+//     <aside>
+      // <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
+//     </aside>
+//   )
+// }
+
+// export default Sidebar
+import React, { createContext, useContext } from 'react';
+import PropTypes from 'prop-types';
+import AppBar from '@material-ui/core/AppBar';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Divider from '@material-ui/core/Divider';
+import Drawer from '@material-ui/core/Drawer';
+import Hidden from '@material-ui/core/Hidden';
+import IconButton from '@material-ui/core/IconButton';
+// import InboxIcon from '@material-ui/icons/MoveToInbox';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+// import  from '@material-ui/core/';
+import ListItemText from '@material-ui/core/ListItemText';
+
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+
+// App Imports
+import AppContext from "../../app/AppContext";
+
+
+
+const drawerWidth = 240;
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+  drawer: {
+    [theme.breakpoints.up('sm')]: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+  },
+  appBar: {
+    [theme.breakpoints.up('sm')]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
+    },
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      display: 'none',
+    },
+  },
+  // necessary for content to be below app bar
+  toolbar: theme.mixins.toolbar,
+  drawerPaper: {
+    width: drawerWidth,
+    backgroundColor: '#EA5455'
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+  },
+}));
+
+function SideBar(props) {
+
+  const [state, dispatch] = useContext(AppContext)
+  const { window } = props;
+  
+  const classes = useStyles();
+  const theme = useTheme();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+console.log(state)
+  const drawer = (
+    <div style={{backgroundColor:`${state.theme.colors.primary}`}}>
+      <div className={classes.toolbar} />
+      <List>
+
+          <ListItem button >
+            <>⭐</>
+            <ListItemText />
+          </ListItem>
+
+      </List>
+    </div>
+  );
+
+  const container = window !== undefined ? () => window().document.body : undefined;
+
   return (
-    <aside>
-      <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
-    </aside>
-  )
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar style={{backgroundColor:`${state.theme.colors.primary}`}} position="fixed" className={classes.appBar}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            className={classes.menuButton}
+          >
+          ⭐
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <nav className={classes.drawer} aria-label="agent-profile">
+        <Hidden smUp implementation="css">
+          <Drawer
+            container={container}
+            variant="temporary"
+            anchor={theme.direction === 'rtl' ? 'right' : 'left'}
+            open={mobileOpen}
+            onClose={handleDrawerToggle}
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            ModalProps={{
+              keepMounted: true,
+            }}
+          >
+            {drawer}
+             <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
+          </Drawer>
+        </Hidden>
+        <Hidden xsDown implementation="css">
+          <Drawer
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            variant="permanent"
+            open
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+      </nav>
+    </div>
+  );
 }
 
-export default Sidebar
+SideBar.propTypes = {
+  window: PropTypes.func,
+};
+
+export default SideBar;

--- a/src/modules/common/sidebar/Sidebar.jsx
+++ b/src/modules/common/sidebar/Sidebar.jsx
@@ -9,14 +9,12 @@ import Divider from '@material-ui/core/Divider';
 import Drawer from '@material-ui/core/Drawer';
 import Hidden from '@material-ui/core/Hidden';
 import IconButton from '@material-ui/core/IconButton';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import Toolbar from '@material-ui/core/Toolbar';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 
 // App Imports
-// import AppContext from "../../app/AppContext";
-import theme from "../../../ui/common/theme"
+import theme from "../../../ui/common/theme";
+import Header from "../header/Header";
 
 const appStyles = theme
 const drawerWidth = 240;
@@ -60,7 +58,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function SideBar(props) {
-  // const [state, dispatch] = useContext(AppContext)
   const { window } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -75,13 +72,7 @@ function SideBar(props) {
       <Toolbar className={classes.toolbar}>AGENT DETAILS</Toolbar>
       <Divider/>
       <div className={classes.drawerPaper} />
-        {/* <Toolbar> */}
-      
-              {/* <div className={classes.drawerPaper}> */}
-                <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
-              {/* </div> */}
-          
-      {/* </Toolbar> */}
+        <img src='http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png' />
     </div>
   );
 
@@ -90,7 +81,6 @@ function SideBar(props) {
   return (
     <div className={classes.root}>
       <CssBaseline />
-      {/* <AppBar  position="fixed" className={classes.appBar}> */}
         <Toolbar>
           <IconButton
             color="inherit"
@@ -102,7 +92,6 @@ function SideBar(props) {
           ⭐
           </IconButton>
         </Toolbar>
-      {/* </AppBar> */}
       <nav className={classes.drawer} aria-label="agent-profile">
         <Hidden smUp implementation="css">
           <Drawer

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -1,0 +1,14 @@
+import PageContainer from "../../ui/containers/PageContainer";
+import TitleContainer from "../../ui/containers/TitleContainer";
+
+const DailyMission = () => {
+  return (
+    <PageContainer>
+      <TitleContainer>
+        <h1>Daily Mission</h1>
+      </TitleContainer>
+    </PageContainer>
+  );
+};
+
+export default DailyMission;

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -1,14 +1,16 @@
-import PageContainer from "../../ui/containers/PageContainer";
 import TitleContainer from "../../ui/containers/TitleContainer";
+import React, { useContext } from "react";
+import AppContext from "../app/AppContext";
 
-const DailyMission = () => {
+const AgentDetails = () => {
   return (
-    <PageContainer>
+    <div>
       <TitleContainer>
-        <h1>Daily Mission</h1>
+        <h1>Agent Name</h1>
       </TitleContainer>
-    </PageContainer>
+        <img src="http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png" />
+    </div>
   );
 };
 
-export default DailyMission;
+export default AgentDetails;

--- a/src/ui/containers/AppContainer.js
+++ b/src/ui/containers/AppContainer.js
@@ -14,12 +14,13 @@ import { makeStyles, useTheme } from "@material-ui/core/styles";
 
 // App Imports
 import theme from "../common/theme";
-import Header from "../../modules/common/header/Header";
+// import Header from "../../modules/common/header/Header";
 import AgentDetails from "../../modules/views/AgentDetails";
 import PageContainer from "./PageContainer";
 
 const appStyles = theme;
-const drawerWidth = "clamp(240px, 30%, 40%)";
+const drawerWidth = 300;
+// "clamp(240px, 30%, 40%)"
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -53,29 +54,17 @@ const useStyles = makeStyles((theme) => ({
   },
   content: {
     flexGrow: 1,
-    marginTop: "20px",
-    backgroundColor: "#282c34",
+    backgroundColor: appStyles.colors.primary,
     fontFamily: "'Russo One', sans-serif",
+    [theme.breakpoints.up("sm")]: {
+      marginLeft: drawerWidth,
+    },
   },
-  // pageContainer: {
-  //   textAlign: "center",
-  //   // backgroundColor: "#282c34",
-  //   margin: "0 6%",
-  //   marginTop: "1%",
-  //   minHeight: "100%",
-  //   display: "flex",
-  //   flexDirection: "column",
-  //   justifyContent: "center",
-  //   alignItems: "center",
-  //   fontSize: "calc(10px + 2vmin)",
-  //   color: "white",
-  //   fontFamily: "'Russo One', sans-serif",
-  // },
   toolbar: theme.mixins.toolbar,
 }));
 
 function AppContainer(props) {
-  const { window, children } = props;
+  const { window } = props;
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -88,7 +77,6 @@ function AppContainer(props) {
     <div>
       <Toolbar className={classes.appBar}>AGENT DETAILS</Toolbar>
       <Divider />
-      {/* Render AgentDetails card here */}
       <AgentDetails />
     </div>
   );
@@ -114,7 +102,7 @@ function AppContainer(props) {
         </Toolbar>
       </AppBar>
       <div className={classes.drawer}>
-        <Hidden smUp implementation="js">
+        <Hidden smUp implementation="css">
           <Drawer
             container={container}
             variant="temporary"
@@ -144,14 +132,10 @@ function AppContainer(props) {
           </Drawer>
         </Hidden>
       </div>
-      {/* <div className={classes.toolbar} /> */}
+
       <main className={classes.content}>
-        {/* <div className={classes.toolbar} /> */}
+        {/* <Header /> */}
         <PageContainer />
-        {/* <section className={classes.pageContainer}>
-          <Header />
-          {children}
-        </section> */}
       </main>
     </div>
   );

--- a/src/ui/containers/AppContainer.js
+++ b/src/ui/containers/AppContainer.js
@@ -1,0 +1,160 @@
+// React Imports
+import React from "react";
+import PropTypes from "prop-types";
+
+// Material-ui Imports
+import AppBar from "@material-ui/core/AppBar";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import Divider from "@material-ui/core/Divider";
+import Drawer from "@material-ui/core/Drawer";
+import Hidden from "@material-ui/core/Hidden";
+import IconButton from "@material-ui/core/IconButton";
+import Toolbar from "@material-ui/core/Toolbar";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+
+// App Imports
+import theme from "../common/theme";
+import Header from "../../modules/common/header/Header";
+import AgentDetails from "../../modules/views/AgentDetails";
+import PageContainer from "./PageContainer";
+
+const appStyles = theme;
+const drawerWidth = "clamp(240px, 30%, 40%)";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "flex",
+  },
+  drawer: {
+    width: drawerWidth,
+    [theme.breakpoints.up("sm")]: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+  },
+  drawerPaper: {
+    width: drawerWidth,
+    backgroundColor: appStyles.colors.primary,
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
+    },
+  },
+  appBar: {
+    backgroundColor: appStyles.colors.primary,
+    fontFamily: "'Russo One', sans-serif",
+    fontSize: "calc(10px + 2vmin)",
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
+    },
+  },
+  content: {
+    flexGrow: 1,
+    marginTop: "20px",
+    backgroundColor: "#282c34",
+    fontFamily: "'Russo One', sans-serif",
+  },
+  // pageContainer: {
+  //   textAlign: "center",
+  //   // backgroundColor: "#282c34",
+  //   margin: "0 6%",
+  //   marginTop: "1%",
+  //   minHeight: "100%",
+  //   display: "flex",
+  //   flexDirection: "column",
+  //   justifyContent: "center",
+  //   alignItems: "center",
+  //   fontSize: "calc(10px + 2vmin)",
+  //   color: "white",
+  //   fontFamily: "'Russo One', sans-serif",
+  // },
+  toolbar: theme.mixins.toolbar,
+}));
+
+function AppContainer(props) {
+  const { window, children } = props;
+  const classes = useStyles();
+  const theme = useTheme();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const drawer = (
+    <div>
+      <Toolbar className={classes.appBar}>AGENT DETAILS</Toolbar>
+      <Divider />
+      {/* Render AgentDetails card here */}
+      <AgentDetails />
+    </div>
+  );
+
+  const container =
+    window !== undefined ? () => window().document.body : undefined;
+
+  return (
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar position="fixed" className={classes.appBar}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            className={classes.menuButton}
+          >
+            ⭐
+          </IconButton>
+          Welcome, Agent Sally!
+        </Toolbar>
+      </AppBar>
+      <div className={classes.drawer}>
+        <Hidden smUp implementation="js">
+          <Drawer
+            container={container}
+            variant="temporary"
+            anchor={theme.direction === "rtl" ? "right" : "left"}
+            open={mobileOpen}
+            onClose={handleDrawerToggle}
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            ModalProps={{
+              keepMounted: true,
+            }}
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+
+        <Hidden xsDown implementation="css">
+          <Drawer
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            variant="permanent"
+            open
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+      </div>
+      {/* <div className={classes.toolbar} /> */}
+      <main className={classes.content}>
+        {/* <div className={classes.toolbar} /> */}
+        <PageContainer />
+        {/* <section className={classes.pageContainer}>
+          <Header />
+          {children}
+        </section> */}
+      </main>
+    </div>
+  );
+}
+
+export default AppContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -112,35 +112,37 @@ function PageContainer(props) {
           Welcome, Agent Sally!
         </Toolbar>
       </AppBar>
+      <div className={classes.drawer}>
+        <Hidden smUp implementation="js">
+          <Drawer
+            container={container}
+            variant="temporary"
+            anchor={theme.direction === "rtl" ? "right" : "left"}
+            open={mobileOpen}
+            onClose={handleDrawerToggle}
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            ModalProps={{
+              keepMounted: true,
+            }}
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
 
-      <Hidden smUp implementation="js">
-        <Drawer
-          container={container}
-          variant="temporary"
-          anchor={theme.direction === "rtl" ? "right" : "left"}
-          open={mobileOpen}
-          onClose={handleDrawerToggle}
-          classes={{
-            paper: classes.drawerPaper,
-          }}
-          ModalProps={{
-            keepMounted: true,
-          }}
-        >
-          {drawer}
-        </Drawer>
-      </Hidden>
-      <Hidden xsDown implementation="css">
-        <Drawer
-          classes={{
-            paper: classes.drawerPaper,
-          }}
-          variant="permanent"
-          open
-        >
-          {drawer}
-        </Drawer>
-      </Hidden>
+        <Hidden xsDown implementation="css">
+          <Drawer
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            variant="permanent"
+            open
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+      </div>
       <main className={classes.content}>
         <div className={classes.toolbar} />
         <section className={classes.pageContainer}>

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
   },
   drawer: {
+    width: drawerWidth,
     [theme.breakpoints.up("sm")]: {
       width: drawerWidth,
       flexShrink: 0,
@@ -39,13 +40,19 @@ const useStyles = makeStyles((theme) => ({
       display: "none",
     },
   },
+  appBar: {
+    backgroundColor: appStyles.colors.primary,
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
+    },
+  },
   content: {
     flexGrow: 1,
-    padding: theme.spacing(3),
   },
   pageContainer: {
     // textAlign: 'center',
-    // backgroundColor: '#282c34',
+    // backgroundColor: "#282c34",
     margin: "0 6%",
     marginTop: "1%",
     minHeight: "100%",
@@ -57,6 +64,7 @@ const useStyles = makeStyles((theme) => ({
     color: "white",
     fontFamily: "'Russo One', sans-serif",
   },
+  toolbar: theme.mixins.toolbar,
 }));
 
 function PageContainer(props) {
@@ -71,7 +79,7 @@ function PageContainer(props) {
 
   const drawer = (
     <div>
-      <Toolbar className={classes.toolbar}>AGENT DETAILS</Toolbar>
+      <Toolbar className={classes.appBar}>AGENT DETAILS</Toolbar>
       <Divider />
       <div className={classes.drawerPaper} />
       <img src="http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png" />
@@ -84,18 +92,33 @@ function PageContainer(props) {
   return (
     <div className={classes.root}>
       <CssBaseline />
-      <Toolbar>
-        <IconButton
-          color="inherit"
-          aria-label="open drawer"
-          edge="start"
-          onClick={handleDrawerToggle}
-          className={classes.menuButton}
-        >
-          ⭐
-        </IconButton>
-      </Toolbar>
-      <nav className={classes.drawer} aria-label="agent-profile">
+      <AppBar position="fixed" className={classes.appBar}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            className={classes.menuButton}
+          >
+            ⭐
+          </IconButton>
+          Responsive drawer
+        </Toolbar>
+      </AppBar>
+      {/* <div className={classes.toolbar} />
+ 
+      <IconButton
+        color="inherit"
+        aria-label="open drawer"
+        edge="start"
+        onClick={handleDrawerToggle}
+        className={classes.menuButton}
+      >
+        ⭐
+      </IconButton> */}
+
+      <div className={classes.drawer} aria-label="agent-profile">
         <Hidden smUp implementation="css">
           <Drawer
             container={container}
@@ -124,7 +147,7 @@ function PageContainer(props) {
             {drawer}
           </Drawer>
         </Hidden>
-      </nav>
+      </div>
       <main className={classes.content}>
         <Header />
         {children}

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -16,6 +16,7 @@ import { makeStyles, useTheme } from "@material-ui/core/styles";
 // App Imports
 import theme from "../common/theme";
 import Header from "../../modules/common/header/Header";
+import AgentDetails from "../../modules/views/AgentDetails";
 
 const appStyles = theme;
 const drawerWidth = 240;
@@ -86,8 +87,8 @@ function PageContainer(props) {
     <div>
       <Toolbar className={classes.appBar}>AGENT DETAILS</Toolbar>
       <Divider />
-      <div className={classes.drawerPaper} />
-      <img src="http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png" />
+      {/* Render AgentDetails card here */}
+      <AgentDetails />
     </div>
   );
 

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -59,15 +59,89 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const PageContainer = ({ children }) => {
+function PageContainer(props) {
+  const { window, children } = props;
   const classes = useStyles();
+  const theme = useTheme();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const drawer = (
+    <div>
+      <Toolbar className={classes.toolbar}>AGENT DETAILS</Toolbar>
+      <Divider />
+      <div className={classes.drawerPaper} />
+      <img src="http://www.clker.com/cliparts/6/8/2/d/15164313681889389218spy-kids-gadgets-clipart.hi.png" />
+    </div>
+  );
+
+  const container =
+    window !== undefined ? () => window().document.body : undefined;
 
   return (
-    <section className={classes.pageContainer}>
-      <Header />
-      {children}
-    </section>
+    <div className={classes.root}>
+      <CssBaseline />
+      <Toolbar>
+        <IconButton
+          color="inherit"
+          aria-label="open drawer"
+          edge="start"
+          onClick={handleDrawerToggle}
+          className={classes.menuButton}
+        >
+          ⭐
+        </IconButton>
+      </Toolbar>
+      <nav className={classes.drawer} aria-label="agent-profile">
+        <Hidden smUp implementation="css">
+          <Drawer
+            container={container}
+            variant="temporary"
+            anchor={theme.direction === "rtl" ? "right" : "left"}
+            open={mobileOpen}
+            onClose={handleDrawerToggle}
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            ModalProps={{
+              keepMounted: true,
+            }}
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+        <Hidden xsDown implementation="css">
+          <Drawer
+            classes={{
+              paper: classes.drawerPaper,
+            }}
+            variant="permanent"
+            open
+          >
+            {drawer}
+          </Drawer>
+        </Hidden>
+      </nav>
+      <main className={classes.content}>
+        <Header />
+        {children}
+      </main>
+    </div>
   );
-};
+}
+
+// const PageContainer = ({ children }) => {
+//   const classes = useStyles();
+
+//   return (
+//     <section className={classes.pageContainer}>
+//       <Header />
+//       {children}
+//     </section>
+//   );
+// };
 
 export default PageContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -49,9 +49,11 @@ const useStyles = makeStyles((theme) => ({
   },
   content: {
     flexGrow: 1,
+    backgroundColor: "#282c34",
+    fontFamily: "'Russo One', sans-serif",
   },
   pageContainer: {
-    // textAlign: 'center',
+    textAlign: "center",
     // backgroundColor: "#282c34",
     margin: "0 6%",
     marginTop: "1%",
@@ -118,8 +120,8 @@ function PageContainer(props) {
         ⭐
       </IconButton> */}
 
-      <div className={classes.drawer} aria-label="agent-profile">
-        <Hidden smUp implementation="css">
+      <nav className={classes.drawer} aria-label="agent-profile">
+        <Hidden smUp implementation="js">
           <Drawer
             container={container}
             variant="temporary"
@@ -147,10 +149,13 @@ function PageContainer(props) {
             {drawer}
           </Drawer>
         </Hidden>
-      </div>
+      </nav>
       <main className={classes.content}>
-        <Header />
-        {children}
+        <div className={classes.toolbar} />
+        <section className={classes.pageContainer}>
+          <Header />
+          {children}
+        </section>
       </main>
     </div>
   );

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -10,6 +10,7 @@ import Drawer from "@material-ui/core/Drawer";
 import Hidden from "@material-ui/core/Hidden";
 import IconButton from "@material-ui/core/IconButton";
 import Toolbar from "@material-ui/core/Toolbar";
+import Container from "@material-ui/core/Toolbar";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 
 // App Imports
@@ -42,6 +43,8 @@ const useStyles = makeStyles((theme) => ({
   },
   appBar: {
     backgroundColor: appStyles.colors.primary,
+    fontFamily: "'Russo One', sans-serif",
+    fontSize: "calc(10px + 2vmin)",
     [theme.breakpoints.up("sm")]: {
       width: `calc(100% - ${drawerWidth}px)`,
       marginLeft: drawerWidth,
@@ -105,51 +108,38 @@ function PageContainer(props) {
           >
             ⭐
           </IconButton>
-          Responsive drawer
+          Welcome, Agent Sally!
         </Toolbar>
       </AppBar>
-      {/* <div className={classes.toolbar} />
- 
-      <IconButton
-        color="inherit"
-        aria-label="open drawer"
-        edge="start"
-        onClick={handleDrawerToggle}
-        className={classes.menuButton}
-      >
-        ⭐
-      </IconButton> */}
 
-      <nav className={classes.drawer} aria-label="agent-profile">
-        <Hidden smUp implementation="js">
-          <Drawer
-            container={container}
-            variant="temporary"
-            anchor={theme.direction === "rtl" ? "right" : "left"}
-            open={mobileOpen}
-            onClose={handleDrawerToggle}
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            ModalProps={{
-              keepMounted: true,
-            }}
-          >
-            {drawer}
-          </Drawer>
-        </Hidden>
-        <Hidden xsDown implementation="css">
-          <Drawer
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            variant="permanent"
-            open
-          >
-            {drawer}
-          </Drawer>
-        </Hidden>
-      </nav>
+      <Hidden smUp implementation="js">
+        <Drawer
+          container={container}
+          variant="temporary"
+          anchor={theme.direction === "rtl" ? "right" : "left"}
+          open={mobileOpen}
+          onClose={handleDrawerToggle}
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          ModalProps={{
+            keepMounted: true,
+          }}
+        >
+          {drawer}
+        </Drawer>
+      </Hidden>
+      <Hidden xsDown implementation="css">
+        <Drawer
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          variant="permanent"
+          open
+        >
+          {drawer}
+        </Drawer>
+      </Hidden>
       <main className={classes.content}>
         <div className={classes.toolbar} />
         <section className={classes.pageContainer}>
@@ -160,16 +150,5 @@ function PageContainer(props) {
     </div>
   );
 }
-
-// const PageContainer = ({ children }) => {
-//   const classes = useStyles();
-
-//   return (
-//     <section className={classes.pageContainer}>
-//       <Header />
-//       {children}
-//     </section>
-//   );
-// };
 
 export default PageContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -1,64 +1,9 @@
-// React Imports
-import React from "react";
-import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/core";
 
-// Material-ui Imports
-import AppBar from "@material-ui/core/AppBar";
-import CssBaseline from "@material-ui/core/CssBaseline";
-import Divider from "@material-ui/core/Divider";
-import Drawer from "@material-ui/core/Drawer";
-import Hidden from "@material-ui/core/Hidden";
-import IconButton from "@material-ui/core/IconButton";
-import Toolbar from "@material-ui/core/Toolbar";
-import Container from "@material-ui/core/Toolbar";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
-
-// App Imports
-import theme from "../common/theme";
-import Header from "../../modules/common/header/Header";
-import AgentDetails from "../../modules/views/AgentDetails";
-
-const appStyles = theme;
-const drawerWidth = 240;
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: "flex",
-  },
-  drawer: {
-    width: drawerWidth,
-    [theme.breakpoints.up("sm")]: {
-      width: drawerWidth,
-      flexShrink: 0,
-    },
-  },
-  drawerPaper: {
-    width: drawerWidth,
-    backgroundColor: appStyles.colors.primary,
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.up("sm")]: {
-      display: "none",
-    },
-  },
-  appBar: {
-    backgroundColor: appStyles.colors.primary,
-    fontFamily: "'Russo One', sans-serif",
-    fontSize: "calc(10px + 2vmin)",
-    [theme.breakpoints.up("sm")]: {
-      width: `calc(100% - ${drawerWidth}px)`,
-      marginLeft: drawerWidth,
-    },
-  },
-  content: {
-    flexGrow: 1,
-    backgroundColor: "#282c34",
-    fontFamily: "'Russo One', sans-serif",
-  },
+const useStyles = makeStyles(() => ({
   pageContainer: {
     textAlign: "center",
-    // backgroundColor: "#282c34",
+    backgroundColor: "#282c34",
     margin: "0 6%",
     marginTop: "1%",
     minHeight: "100%",
@@ -70,88 +15,12 @@ const useStyles = makeStyles((theme) => ({
     color: "white",
     fontFamily: "'Russo One', sans-serif",
   },
-  toolbar: theme.mixins.toolbar,
 }));
 
-function PageContainer(props) {
-  const { window, children } = props;
+const PageContainer = ({ children }) => {
   const classes = useStyles();
-  const theme = useTheme();
-  const [mobileOpen, setMobileOpen] = React.useState(false);
 
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
-  };
-
-  const drawer = (
-    <div>
-      <Toolbar className={classes.appBar}>AGENT DETAILS</Toolbar>
-      <Divider />
-      {/* Render AgentDetails card here */}
-      <AgentDetails />
-    </div>
-  );
-
-  const container =
-    window !== undefined ? () => window().document.body : undefined;
-
-  return (
-    <div className={classes.root}>
-      <CssBaseline />
-      <AppBar position="fixed" className={classes.appBar}>
-        <Toolbar>
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            edge="start"
-            onClick={handleDrawerToggle}
-            className={classes.menuButton}
-          >
-            ⭐
-          </IconButton>
-          Welcome, Agent Sally!
-        </Toolbar>
-      </AppBar>
-      <div className={classes.drawer}>
-        <Hidden smUp implementation="js">
-          <Drawer
-            container={container}
-            variant="temporary"
-            anchor={theme.direction === "rtl" ? "right" : "left"}
-            open={mobileOpen}
-            onClose={handleDrawerToggle}
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            ModalProps={{
-              keepMounted: true,
-            }}
-          >
-            {drawer}
-          </Drawer>
-        </Hidden>
-
-        <Hidden xsDown implementation="css">
-          <Drawer
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            variant="permanent"
-            open
-          >
-            {drawer}
-          </Drawer>
-        </Hidden>
-      </div>
-      <main className={classes.content}>
-        <div className={classes.toolbar} />
-        <section className={classes.pageContainer}>
-          <Header />
-          {children}
-        </section>
-      </main>
-    </div>
-  );
-}
+  return <section className={classes.pageContainer}>{children}</section>;
+};
 
 export default PageContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -1,11 +1,11 @@
 import { makeStyles } from "@material-ui/core";
 
-const useStyles = makeStyles(() => ({
+const drawerWidth = 300;
+const useStyles = makeStyles((theme) => ({
   pageContainer: {
     textAlign: "center",
     backgroundColor: "#282c34",
-    margin: "0 6%",
-    marginTop: "1%",
+    marginTop: "25px",
     minHeight: "100%",
     display: "flex",
     flexDirection: "column",
@@ -14,13 +14,17 @@ const useStyles = makeStyles(() => ({
     fontSize: "calc(10px + 2vmin)",
     color: "white",
     fontFamily: "'Russo One', sans-serif",
+    // media query for pushing page content past drawer
+    [theme.breakpoints.up("sm")]: {
+      marginLeft: drawerWidth,
+    },
   },
 }));
 
 const PageContainer = ({ children }) => {
   const classes = useStyles();
 
-  return <section className={classes.pageContainer}>{children}</section>;
+  return <div className={classes.pageContainer}>{children}</div>;
 };
 
 export default PageContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -1,32 +1,47 @@
-import {makeStyles} from '@material-ui/core'
+// React Imports
+import React from "react";
+import PropTypes from "prop-types";
+
+// Material-ui Imports
+import AppBar from "@material-ui/core/AppBar";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import Divider from "@material-ui/core/Divider";
+import Drawer from "@material-ui/core/Drawer";
+import Hidden from "@material-ui/core/Hidden";
+import IconButton from "@material-ui/core/IconButton";
+import Toolbar from "@material-ui/core/Toolbar";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+
+// App Imports
+import theme from "../common/theme";
+import Header from "../../modules/common/header/Header";
 
 const useStyles = makeStyles(() => ({
   pageContainer: {
     // textAlign: 'center',
     // backgroundColor: '#282c34',
-    margin: '0 6%',
-    marginTop: '1%',
-    minHeight: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    fontSize: 'calc(10px + 2vmin)',
-    color: 'white',
+    margin: "0 6%",
+    marginTop: "1%",
+    minHeight: "100%",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    fontSize: "calc(10px + 2vmin)",
+    color: "white",
     fontFamily: "'Russo One', sans-serif",
-  }
-}))
+  },
+}));
 
+const PageContainer = ({ children }) => {
+  const classes = useStyles();
 
-
-const PageContainer = ({children}) => {
-  const classes = useStyles()
-
-  return ( 
+  return (
     <section className={classes.pageContainer}>
+      <Header />
       {children}
     </section>
-   );
-}
- 
+  );
+};
+
 export default PageContainer;

--- a/src/ui/containers/PageContainer.js
+++ b/src/ui/containers/PageContainer.js
@@ -16,7 +16,33 @@ import { makeStyles, useTheme } from "@material-ui/core/styles";
 import theme from "../common/theme";
 import Header from "../../modules/common/header/Header";
 
-const useStyles = makeStyles(() => ({
+const appStyles = theme;
+const drawerWidth = 240;
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "flex",
+  },
+  drawer: {
+    [theme.breakpoints.up("sm")]: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+  },
+  drawerPaper: {
+    width: drawerWidth,
+    backgroundColor: appStyles.colors.primary,
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
+    },
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+  },
   pageContainer: {
     // textAlign: 'center',
     // backgroundColor: '#282c34',

--- a/src/ui/containers/TitleContainer.js
+++ b/src/ui/containers/TitleContainer.js
@@ -1,11 +1,11 @@
-import {makeStyles} from '@material-ui/core'
+import { makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles(() => ({
   titleContainer: {
-    textAlign: 'center',
-    margin: '0 2%',
-    width: '100%',
-    justifyContent: 'center',
+    textAlign: "center",
+    justifyContent: "center",
+    // margin: '0 2%',
+    // width: '100%',
     // backgroundColor: '#282c34',
     // alignItems: 'center',
     // minHeight: '100%',
@@ -14,17 +14,13 @@ const useStyles = makeStyles(() => ({
     // fontSize: 'calc(10px + 2vmin)',
     // color: 'white',
     // fontFamily: "'Russo One', sans-serif",
-  }
-}))
+  },
+}));
 
-const TitleContainer = ({children}) => {
-  const classes = useStyles()
+const TitleContainer = ({ children }) => {
+  const classes = useStyles();
 
-  return ( 
-    <div className={classes.titleContainer}>
-      {children}
-    </div>
-   );
-}
- 
+  return <div className={classes.titleContainer}>{children}</div>;
+};
+
 export default TitleContainer;


### PR DESCRIPTION
### What does this pull request do?
- Adds responsive `AppContainer` component, which renders PageContainer
- - Includes side drawer and header (AppBar) from material-ui
- - Side drawer is responsive: Closes completely on xs/mobile screen with icon button to open and closes on touch/click anywhere else in window; Permanent fixture on small+ screen size
- Adds `PageContainer` component to render all child modules/views (which access global state)
- Adds basic `AgentDetails` to modules/views; It is rendered in PageContainer (side drawer content)
- App.js: Changes Route for mission-details to include :id param using match, sets up for API calls 

### What files were changed?
- src/modules/app/App.js
- src/modules/views/AgentDetails.jsx
- src/ui/containers/AppContainer.js
- src/ui/containers/PageContainer.js

### Issues
#9 : Creates sidebar in AppContainer component
#31 : Combination of makeStyles() and import theme props from ui/common/theme

### Next steps
- Build out AgentDetails component for side drawer, remove theme from state, build out remaining modules/views

### Screenshots / Gifs
#### Closed Drawer (Mobile) **Empty space should not render on your device screens (styling id in devtools is `#blockColorblindContent`)
![Closed Drawer](https://user-images.githubusercontent.com/68264128/108780116-30544180-7525-11eb-9005-3e1e2a78d7de.png)
#### Open Drawer (Mobile)
![Open Drawer](https://user-images.githubusercontent.com/68264128/108780024-0dc22880-7525-11eb-95a3-e9df41d16179.png)
#### Open Drawer Persist on Small+ Screen Size
![Open Drawer Permanent Big Screen](https://user-images.githubusercontent.com/68264128/108780064-1dda0800-7525-11eb-854c-6307be989538.png)



