### PR TITLE
Accessibility/parent child views

### DIFF
--- a/src/modules/common/appReducer.js
+++ b/src/modules/common/appReducer.js
@@ -7,32 +7,34 @@ export const initialState = {
   selectedMissionTasks: [],
   tasks: [],
   selectedTask: {},
-  status: '',
+  status: "",
   parentId: null,
   theme,
 };
 
 export const appReducer = (state, action) => {
-  switch(action.type) {
-    case 'FETCH_MISSIONS':
-      return {...state, missions: action.missions}
-    case 'FETCH_SELECTEDMISSION':
-      return {...state, selectedMission: action.selectedMission}
-    case 'FETCH_SELECTEDMISSIONTASKS':
-      return {...state, selectedMissionTasks: action.selectedMissionTasks}
-    case 'FETCH_SELECTED_TASK':
-      return { ...state, selectedTask: action.selectedTask }
-    case 'FETCH_TASKS':
-      return { ...state, tasks: action.tasks }
-    case 'SET_STATUS':
-      return { ...state, status: action.status }
-    case 'SET_CURRENT_USER':
-      return { ...state, currentUser: action.currentUser }
-    case 'SET_PARENT_ID':
-      return { ...state, parentId: action.parentId }
-    case 'SET_REDEEMED':
-      return { ...state, redeemed: action.redeemed }
+  switch (action.type) {
+    case "FETCH_MISSIONS":
+      return { ...state, missions: action.missions };
+    case "FETCH_SELECTEDMISSION":
+      return { ...state, selectedMission: action.selectedMission };
+    case "FETCH_SELECTEDMISSIONTASKS":
+      return { ...state, selectedMissionTasks: action.selectedMissionTasks };
+    case "FETCH_SELECTED_TASK":
+      return { ...state, selectedTask: action.selectedTask };
+    case "FETCH_TASKS":
+      return { ...state, tasks: action.tasks };
+    case "SET_STATUS":
+      return { ...state, status: action.status };
+    case "SET_CURRENT_USER":
+      return { ...state, currentUser: action.currentUser };
+    case "SET_CURRENT_USER_STATS":
+      return { ...state, currentUserStats: action.currentUserStats };
+    case "SET_PARENT_ID":
+      return { ...state, parentId: action.parentId };
+    case "SET_REDEEMED":
+      return { ...state, redeemed: action.redeemed };
     default:
       return state;
   }
-}
+};

--- a/src/modules/parents/ChildList.js
+++ b/src/modules/parents/ChildList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   FormHelperText,
   Select,
@@ -6,44 +6,50 @@ import {
   MenuItem,
 } from "@material-ui/core";
 
-const ChildList = ({children, childList, selection, updateSelection}) => {
+const ChildList = ({ children, childList, selection, updateSelection }) => {
   const [child, setChild] = React.useState("");
 
   useEffect(() => {
-    if (child !== selection) setChild(selection)
-  }, [selection])
+    if (child !== selection) setChild(selection);
+  }, [selection]);
 
-  const handleChange = event => {
-    console.log(event.target.value)
+  const handleChange = (event) => {
+    console.log(event.target.value);
     setChild(event.target.value);
-    updateSelection(event.target.value)
+    updateSelection(event.target.value);
   };
 
   const renderChildList = () => {
     return childList.map((u) => (
-      <MenuItem key={Math.random()} value={u.data}>
+      <MenuItem key={Math.random()} value={u.data} aria-label={`${child}`}>
         {u.data.attributes.name}
       </MenuItem>
     ));
   };
 
-  return ( 
+  return (
     <>
-      <InputLabel id="demo-simple-select-helper-label">Child</InputLabel>
+      <InputLabel
+        id="select-child-placeholder"
+        aria-label="child name placeholder"
+      >
+        Child
+      </InputLabel>
       <Select
-        labelId="demo-simple-select-helper-label"
-        id="demo-simple-select-helper"
+        labelId={`select-${child}-label`}
+        id={`select-${child}`}
         value={child}
+        aria-label={`select agent ${child}`}
         onChange={handleChange}
       >
-      <MenuItem key={'no-selection'} value="">
-        <em>None</em>
-      </MenuItem>
-      {renderChildList()}
+        <MenuItem key={"no-selection"} value="">
+          <em>None</em>
+        </MenuItem>
+        {renderChildList()}
       </Select>
       <FormHelperText>{children}</FormHelperText>
     </>
-   );
-}
- 
+  );
+};
+
 export default React.memo(ChildList);

--- a/src/modules/parents/NewChildForm.js
+++ b/src/modules/parents/NewChildForm.js
@@ -1,35 +1,45 @@
 import React from "react";
 import { TitleContainer } from "../../ui/containers/index";
-import {
-  FormHelperText,
-  TextField,
-  Button
-} from "@material-ui/core";
+import { FormHelperText, TextField, Button } from "@material-ui/core";
 
-const NewChildForm = ({addChild}) => {
+const NewChildForm = ({ addChild }) => {
   const [newChildName, setNewChildName] = React.useState("");
 
   const handleClick = () => {
-    addChild(newChildName)
-    setNewChildName('')
-  }
+    addChild(newChildName);
+    setNewChildName("");
+  };
 
   return (
     <>
-      <TitleContainer><h1 style={{fontSize: '1em', marginTop: '.4em', marginBottom: '.1em' }}>Add a child</h1></TitleContainer>      
-      <FormHelperText style={{margin:'1em', textAlign: 'center'}}>
-        Add your KidDo Agents by name and we'll send them your missions! 
+      <TitleContainer>
+        <h1
+          style={{ fontSize: "1em", marginTop: ".4em", marginBottom: ".1em" }}
+        >
+          Add a child
+        </h1>
+      </TitleContainer>
+      <FormHelperText style={{ margin: "1em", textAlign: "center" }}>
+        Add your KidDo Agents by name and we'll send them your missions!
       </FormHelperText>
       <TextField
-          id="outlined-basic"
-          label="KidDo Agent Name"
-          variant="outlined"
-          value={newChildName}
-          onChange={(event) => setNewChildName(event.target.value)}
-        />
-      <Button style={{margin: '1em'}} onClick={() => handleClick()} disabled={newChildName ? false : true} variant="contained" color="primary">
-        {newChildName ? 'Add KidDo Agent!' : 'Add Agent Details'}
-      </Button> 
+        id="outlined-basic"
+        label="KidDo Agent Name"
+        aria-label="input new child agent name"
+        variant="outlined"
+        value={newChildName}
+        onChange={(event) => setNewChildName(event.target.value)}
+      />
+      <Button
+        style={{ margin: "1em" }}
+        onClick={() => handleClick()}
+        disabled={newChildName ? false : true}
+        aria-label="Add new KidDo agent"
+        variant="contained"
+        color="primary"
+      >
+        {newChildName ? "Add KidDo Agent!" : "Add Agent Details"}
+      </Button>
     </>
   );
 };

--- a/src/modules/parents/NewChildForm.js
+++ b/src/modules/parents/NewChildForm.js
@@ -33,6 +33,7 @@ const NewChildForm = ({ addChild }) => {
         style={{ margin: "1em" }}
         onClick={() => handleClick()}
         disabled={newChildName ? false : true}
+        aria-label="Add new KidDo agent"
         variant="contained"
         color="primary"
       >

--- a/src/modules/parents/NewChildForm.js
+++ b/src/modules/parents/NewChildForm.js
@@ -23,9 +23,8 @@ const NewChildForm = ({ addChild }) => {
         Add your KidDo Agents by name and we'll send them your missions!
       </FormHelperText>
       <TextField
-        id="outlined-basic"
+        id="input-agent-name"
         label="KidDo Agent Name"
-        aria-label="input new child agent name"
         variant="outlined"
         value={newChildName}
         onChange={(event) => setNewChildName(event.target.value)}
@@ -34,7 +33,6 @@ const NewChildForm = ({ addChild }) => {
         style={{ margin: "1em" }}
         onClick={() => handleClick()}
         disabled={newChildName ? false : true}
-        aria-label="Add new KidDo agent"
         variant="contained"
         color="primary"
       >

--- a/src/modules/parents/RewardForm.js
+++ b/src/modules/parents/RewardForm.js
@@ -1,48 +1,45 @@
 import React, { useState, useEffect } from "react";
 import { TitleContainer } from "../../ui/containers/index";
-import {
-  FormHelperText,
-  TextField,
-  Button
-} from "@material-ui/core";
+import { FormHelperText, TextField, Button } from "@material-ui/core";
 
-const RewardForm = ({parentId, children, childId, handleRewardSubmit}) => {
-  const [rewardName, setRewardName] = React.useState('');
-  const [rewardDescription, setRewardDescription] = React.useState('');
-  const [rewardPoints, setRewardPoints] = React.useState('');
+const RewardForm = ({ parentId, children, childId, handleRewardSubmit }) => {
+  const [rewardName, setRewardName] = React.useState("");
+  const [rewardDescription, setRewardDescription] = React.useState("");
+  const [rewardPoints, setRewardPoints] = React.useState("");
   const [ready, setReady] = React.useState(false);
 
   useEffect(() => {
     if (rewardName && rewardDescription && rewardPoints && childId) {
-      setReady(true)
+      setReady(true);
     } else {
-      setReady(false)
+      setReady(false);
     }
-  }, [rewardName, rewardDescription, rewardPoints, childId])
+  }, [rewardName, rewardDescription, rewardPoints, childId]);
 
-  const submitReward= () => {
+  const submitReward = () => {
     const rewardObject = {
-      "title": rewardName,
-      "points_to_redeem": rewardPoints,
-      "parent_id": parentId,
-      "user_id": childId,
-      "description": rewardDescription
-    }
-    handleRewardSubmit(rewardObject)
-    clearInputs()
-  }
+      title: rewardName,
+      points_to_redeem: rewardPoints,
+      parent_id: parentId,
+      user_id: childId,
+      description: rewardDescription,
+    };
+    handleRewardSubmit(rewardObject);
+    clearInputs();
+  };
 
   const clearInputs = () => {
-    setRewardName('')
-    setRewardDescription('')
-    setRewardPoints('')
-  }
+    setRewardName("");
+    setRewardDescription("");
+    setRewardPoints("");
+  };
 
   return (
     <>
       <TitleContainer>
         <h1
-          style={{ fontSize: "1em", marginTop: ".4em", marginBottom: ".1em" }}>
+          style={{ fontSize: "1em", marginTop: ".4em", marginBottom: ".1em" }}
+        >
           Add a Parent Reward
         </h1>
       </TitleContainer>
@@ -52,33 +49,33 @@ const RewardForm = ({parentId, children, childId, handleRewardSubmit}) => {
         Once they have enough points, they can purchase your reward!
       </FormHelperText>
       <TextField
-        style={{marginBottom: '.3em'}}
-        id="outlined-basic"
+        style={{ marginBottom: ".3em" }}
+        id="reward-name-input"
         label="Reward Name"
         placeholder="Add a simple name for this reward"
         variant="outlined"
         value={rewardName}
-        onChange={event => setRewardName(event.target.value)}
+        onChange={(event) => setRewardName(event.target.value)}
       />
       <TextField
-        style={{marginBottom: '.3em'}}
-        id="outlined-basic"
+        style={{ marginBottom: ".3em" }}
+        id="reward-description-input"
         label="Reward Description"
         placeholder="What are the details of this reward?"
         variant="outlined"
         value={rewardDescription}
-        onChange={event => setRewardDescription(event.target.value)}
+        onChange={(event) => setRewardDescription(event.target.value)}
       />
       <TextField
-        style={{marginBottom: '.3em'}}
-        id="outlined-basic"
-        type="number" 
+        style={{ marginBottom: ".3em" }}
+        id="reward-cost-input"
+        type="number"
         pattern="[0-9]+-"
         label="Reward Point Value"
         placeholder="Tasks average 5 points each"
         variant="outlined"
         value={rewardPoints}
-        onChange={event => setRewardPoints(event.target.value)} //TODO no decimals allowed
+        onChange={(event) => setRewardPoints(event.target.value)} //TODO no decimals allowed
       />
       <FormHelperText style={{ textAlign: "center" }}>
         Remember each preloaded task is worth between 5-10 points!
@@ -90,7 +87,8 @@ const RewardForm = ({parentId, children, childId, handleRewardSubmit}) => {
         disabled={ready ? false : true}
         variant="contained"
         onClick={submitReward}
-        color="primary">
+        color="primary"
+      >
         {ready ? "Add Reward!" : "Add more reward details"}
       </Button>
     </>

--- a/src/modules/parents/RewardForm.js
+++ b/src/modules/parents/RewardForm.js
@@ -88,6 +88,7 @@ const RewardForm = ({ parentId, children, childId, handleRewardSubmit }) => {
         variant="contained"
         onClick={submitReward}
         color="primary"
+        aria-label="Submit new reward"
       >
         {ready ? "Add Reward!" : "Add more reward details"}
       </Button>

--- a/src/modules/parents/TransferList.js
+++ b/src/modules/parents/TransferList.js
@@ -158,7 +158,7 @@ export default function TransferList({ getChoices, children }) {
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple
-                  inputProps={{ "aria-labelledby": labelId }}
+                  inputProps={{ "aria-label": labelId }}
                 />
               </ListItemIcon>
               <ListItemText id={labelId} primary={`${value}`} />

--- a/src/modules/parents/TransferList.js
+++ b/src/modules/parents/TransferList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import AppContext from '../../modules/App/AppContext'
+import AppContext from "../../modules/App/AppContext";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import List from "@material-ui/core/List";
@@ -12,7 +12,7 @@ import Checkbox from "@material-ui/core/Checkbox";
 import Button from "@material-ui/core/Button";
 import Divider from "@material-ui/core/Divider";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     margin: "auto",
   },
@@ -38,18 +38,18 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function not(a, b) {
-  return a.filter(value => b.indexOf(value) === -1);
+  return a.filter((value) => b.indexOf(value) === -1);
 }
 
 function intersection(a, b) {
-  return a.filter(value => b.indexOf(value) !== -1);
+  return a.filter((value) => b.indexOf(value) !== -1);
 }
 
 function union(a, b) {
   return [...a, ...not(b, a)];
 }
 
-export default function TransferList({getChoices, children}) {
+export default function TransferList({ getChoices, children }) {
   const classes = useStyles();
   const [state, dispatch] = useContext(AppContext);
   const [checked, setChecked] = React.useState([]);
@@ -57,35 +57,35 @@ export default function TransferList({getChoices, children}) {
   const [right, setRight] = React.useState([]);
 
   useEffect(() => {
-    setLeft(generateTaskChoices())
-  }, [state.tasks])
-  
+    setLeft(generateTaskChoices());
+  }, [state.tasks]);
+
   useEffect(() => {
     const taskIdList = right.reduce((acc, t) => {
-      acc.push(t.split(' ')[0])
-      return acc
-    }, [])
-    
+      acc.push(t.split(" ")[0]);
+      return acc;
+    }, []);
+
     const taskObjects = taskIdList.reduce((acc, id) => {
-      const match = state.tasks.find(t => t.id === id)
-      acc.push(match)
-      return acc
-    }, [])
+      const match = state.tasks.find((t) => t.id === id);
+      acc.push(match);
+      return acc;
+    }, []);
 
     getChoices(taskObjects);
-  }, [right])
-  
+  }, [right]);
+
   const generateTaskChoices = () => {
     return state.tasks.reduce((acc, t) => {
-      acc.push(t.id + ' ' + t.attributes.name)
-      return acc
-    }, [])
-  }
+      acc.push(t.id + " " + t.attributes.name);
+      return acc;
+    }, []);
+  };
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
 
-  const handleToggle = value => () => {
+  const handleToggle = (value) => () => {
     const currentIndex = checked.indexOf(value);
     const newChecked = [...checked];
 
@@ -98,9 +98,9 @@ export default function TransferList({getChoices, children}) {
     setChecked(newChecked);
   };
 
-  const numberOfChecked = items => intersection(checked, items).length;
+  const numberOfChecked = (items) => intersection(checked, items).length;
 
-  const handleToggleAll = items => () => {
+  const handleToggleAll = (items) => () => {
     if (numberOfChecked(items) === items.length) {
       setChecked(not(checked, items));
     } else {
@@ -143,7 +143,7 @@ export default function TransferList({getChoices, children}) {
       />
       <Divider />
       <List className={classes.list} dense component="div" role="list">
-        {items.map(value => {
+        {items.map((value) => {
           const labelId = `transfer-list-all-item-${value}-label`;
 
           return (
@@ -151,7 +151,8 @@ export default function TransferList({getChoices, children}) {
               key={value}
               role="listitem"
               button
-              onClick={handleToggle(value)}>
+              onClick={handleToggle(value)}
+            >
               <ListItemIcon>
                 <Checkbox
                   checked={checked.indexOf(value) !== -1}
@@ -175,33 +176,35 @@ export default function TransferList({getChoices, children}) {
       spacing={2}
       justify="center"
       alignItems="center"
-      className={classes.root}>
+      className={classes.root}
+    >
       <Grid item>{customList("Tasks", left)}</Grid>
       <Grid item>
         <Grid container direction="column" alignItems="center">
-          
           {children}
-          
+
           <Button
-            style={{borderWidth: '3px', fontWeight: 'bold'}}
-            color='primary'
+            style={{ borderWidth: "3px", fontWeight: "bold" }}
+            color="primary"
             variant="outlined"
             size="small"
             className={classes.button}
             onClick={handleCheckedRight}
             disabled={leftChecked.length === 0}
-            aria-label="move selected right">
+            aria-label="move selected right"
+          >
             Add Task
           </Button>
           <Button
-            style={{borderWidth: '3px', fontWeight: 'bold'}}
-            color='primary'
+            style={{ borderWidth: "3px", fontWeight: "bold" }}
+            color="primary"
             variant="outlined"
             size="small"
             className={classes.button}
             onClick={handleCheckedLeft}
             disabled={rightChecked.length === 0}
-            aria-label="move selected left">
+            aria-label="move selected left"
+          >
             Remove Task
           </Button>
         </Grid>

--- a/src/modules/rewards/RewardCard.jsx
+++ b/src/modules/rewards/RewardCard.jsx
@@ -61,8 +61,8 @@ const RewardCard = ({ reward }) => {
   const [state, dispatch] = useContext(AppContext);
 
   const checkForPurchase = (pointValue) => {
-    // if (state.currentUser?.attributes.points >= pointValue) {
-    if (!reward.attributes.redeemed) {
+    if (state.currentUser?.attributes.points >= pointValue && !reward.attributes.redeemed) {
+    // if (!reward.attributes.redeemed) {
       return (
         <Button style={{zIndex: 100, width: 'fit-content'}} onClick={() => redeem()}>Redeem Reward!</Button>
       )

--- a/src/modules/rewards/RewardCard.jsx
+++ b/src/modules/rewards/RewardCard.jsx
@@ -1,11 +1,9 @@
 import { useContext } from "react"
-import RoundButton from "../../ui/button/RoundButton"
 import AppContext from "../App/AppContext"
 import { redeemReward } from "../common/apiCalls";
 import { makeStyles } from "@material-ui/core";
 import theme from "../../ui/common/theme";
 import Button from "../../ui/button/Button";
-import GoldCoinRain from "../../ui/animations/goldCoinRain";
 
 const appStyles = theme
 

--- a/src/modules/task/Task.js
+++ b/src/modules/task/Task.js
@@ -177,6 +177,7 @@ const Task = ({ props }) => {
           className={classes.link}
           key={props.id}
           to={`/task/${props.id}`}
+          aria-label={`link to task ${props.attributes.task_name}`}
         >
           {taskCard()}
         </Link>
@@ -204,7 +205,11 @@ const Task = ({ props }) => {
               >
                 <b>Agent notes:</b> {message}
               </i>
-              <img className={classes.taskImage} src={image_path} />
+              <img
+                className={classes.taskImage}
+                src={image_path}
+                alt={`photo-evidence`}
+              />
             </span>
           ) : (
             task_description

--- a/src/modules/task/Task.js
+++ b/src/modules/task/Task.js
@@ -177,7 +177,7 @@ const Task = ({ props }) => {
           className={classes.link}
           key={props.id}
           to={`/task/${props.id}`}
-          aria-label={`link to task ${props.attributes.task_name}`}
+          // aria-label={`link to task ${props.attributes.task_name}`}
         >
           {taskCard()}
         </Link>
@@ -208,7 +208,7 @@ const Task = ({ props }) => {
               <img
                 className={classes.taskImage}
                 src={image_path}
-                alt={`photo-evidence`}
+                // alt="photo-evidence"
               />
             </span>
           ) : (

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -156,7 +156,7 @@ const AgentDetails = props => {
       <div className={classes.card}>
         <div className={classes.cardHeader}>
           <div className={classes.avatar} onClick={() => determinePath()}>
-            <img src={kids} />
+            <img src={kids} alt="KidDo Agents smiling logo"/>
           </div>
           <span className={classes.titleText}>
             <h1>

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -114,7 +114,7 @@ const AgentDetails = props => {
     if (sessionUser !== null && sessionUser.type === 'user') {
       updateUserDetails();
     }
-  }, [state.selectedTask, state.redeemed]);
+  }, [state.selectedTask, , state.currentUserStats]);
 
   const updateUserDetails = async () => {
     const userPoints = sessionUser.attributes.points

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -114,7 +114,7 @@ const AgentDetails = props => {
     if (sessionUser !== null && sessionUser.type === 'user') {
       updateUserDetails();
     }
-  }, [state.selectedTask]);
+  }, [state.selectedTask, state.redeemed]);
 
   const updateUserDetails = async () => {
     const userPoints = sessionUser.attributes.points

--- a/src/modules/views/AgentDetails.jsx
+++ b/src/modules/views/AgentDetails.jsx
@@ -104,7 +104,7 @@ const AgentDetails = props => {
   useEffect(() => {
     if (state.currentUser && state.currentUser.type === "user") {
       setSessionUser(state.currentUser);
-      determinePath();
+      // determinePath();
     } else {
       setSessionUser(null);
     }

--- a/src/modules/views/AgentStats.jsx
+++ b/src/modules/views/AgentStats.jsx
@@ -88,14 +88,22 @@ const AgentStats = () => {
   const [open, setOpen] = React.useState(false);
   
 
-  useEffect(async () => {
+  useEffect(() => {
     if (state.currentUser?.type === "user") {
-      const fetchedStats = await getUserStats(state.currentUser.id)
-      if (fetchedStats && fetchedStats !== userStats) {
-        createStats(fetchedStats)
-      }
+      determineStats()
+      setUserStatsInState(userStats)   
     }
   }, [userStats])
+  
+  const setUserStatsInState = (statsData) => {
+    const action = {type: "SET_CURRENT_USER_STATS", currentUserStats: statsData}
+    dispatch(action)
+  }
+
+  const determineStats = async () => {
+    const fetchedStats = await getUserStats(state.currentUser.id).then(data => createStats(data))
+    return fetchedStats
+  }
 
   const createStats = (stats) => {
     const statsWithIcons = stats.map(stat => {

--- a/src/modules/views/AgentStats.jsx
+++ b/src/modules/views/AgentStats.jsx
@@ -89,7 +89,7 @@ const AgentStats = () => {
   
 
   useEffect(async () => {
-    if (state.currentUser.type === "user") {
+    if (state.currentUser?.type === "user") {
       const fetchedStats = await getUserStats(state.currentUser.id)
       if (fetchedStats && fetchedStats !== userStats) {
         createStats(fetchedStats)

--- a/src/modules/views/AgentStats.jsx
+++ b/src/modules/views/AgentStats.jsx
@@ -95,7 +95,7 @@ const AgentStats = () => {
         createStats(fetchedStats)
       }
     }
-  }, [setUserStats])
+  }, [userStats])
 
   const createStats = (stats) => {
     const statsWithIcons = stats.map(stat => {
@@ -116,7 +116,8 @@ const AgentStats = () => {
         return stat
       } 
       else {
-        // stat.icon = brainTraining
+        // This is to account for original tasks
+        // created for development with category "IQ, EQ", etc.
         return stat
       }
     })

--- a/src/modules/views/ParentView.jsx
+++ b/src/modules/views/ParentView.jsx
@@ -146,17 +146,18 @@ const ParentView = () => {
           <TextField
             id="outlined-basic"
             label="Mission Title"
+            aria-label="mission title"
             variant="outlined"
             value={missionName}
             onChange={(event) => setMissionName(event.target.value)}
           />
-          <FormHelperText style={{margin:'1em'}}id="my-helper-text">
+          <FormHelperText style={{margin:'1em'}}id="my-helper-text" aria-label="mission-name-helper-text">
             This is the name of the mission your child will see 🥳 
           </FormHelperText>
             <TransferList getChoices={getChoices}>
               <TaskCreation />
             </TransferList>
-            <FormHelperText style={{margin:'1em', textAlign:'center'}}id="my-helper-text">
+            <FormHelperText style={{margin:'1em', textAlign:'center'}}id="my-helper-text" aria-label="task-selection-helper-text">
               Pick at least one, but no more than four tasks per mission!
             </FormHelperText>
         </FormControl>

--- a/src/modules/views/RewardStore.jsx
+++ b/src/modules/views/RewardStore.jsx
@@ -30,7 +30,7 @@ container: {
 },
 coin: {
   height: "60px",
-  margin: "30px",
+  margin: "0 30px 0 30px",
   alignSelf: "center",
   animation: "$spin infinite ease 2s"
   },

--- a/src/modules/views/RewardStore.jsx
+++ b/src/modules/views/RewardStore.jsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { getRewardsByUserId, redeemReward } from "../common/apiCalls";
-import { PageContainer } from "../../ui/containers";
+import { PageContainer, TitleContainer } from "../../ui/containers";
 import AppContext from "../App/AppContext";
 import RewardCard from "../rewards/RewardCard";
 import { coin } from "../../assets/index";
@@ -85,13 +85,15 @@ const RewardStore = ({ id }) => {
     <PageContainer>
       <div className={classes.title}>
         <img src={coin.img} alt="gold coin" className={classes.coin}/>
-        <h1>Reward Store</h1>
+        <TitleContainer>
+          <h1>Reward Store</h1>
+        </TitleContainer>
         <img src={coin.img} alt="gold coin" className={classes.coin}/>
       </div>
       
-      <h3 style={{fontFamily: appStyles.fonts.secondary, color: appStyles.colors.white}}>
-        {rewards.length ? "Click 'Buy' to Purchase Your Reward!" : "Ask HQ to add a reward!"}
-      </h3>
+      <h2 style={{fontFamily: appStyles.fonts.secondary, fontSize: "24px", color: appStyles.colors.white}}>
+        {rewards.length ? "Click REDEEM to Purchase Your Reward!" : "Ask HQ to add a reward!"}
+      </h2>
       
       <div className={classes.container}>
         { makeRewardCards() }

--- a/src/modules/views/Welcome.jsx
+++ b/src/modules/views/Welcome.jsx
@@ -4,8 +4,8 @@ import { PageContainer, TitleContainer } from "../../ui/containers";
 import { brainTraining, healthTraining, creativityTraining, basicTraining } from "../../assets/index";
 import theme from "../../ui/common/theme";
 import AppContext from "../App/AppContext";
-import { Link } from "react-router-dom";
-import UserIndex from "../login/UserIndex";
+// import { Link } from "react-router-dom";
+// import UserIndex from "../login/UserIndex";
 import ModalWrapper from "../../ui/modal/ModalWrapper";
 
 
@@ -181,15 +181,6 @@ const Welcome = () => {
             Depending on the task, you’ll either be asked to write a prompt or submit a picture. Remember, since we’re on the internet, never take pictures of yourself, your family, or anything that might reveal personal information! 
           </p>
           <p>Have fun and stay safe 😎.</p>
-        {/* {!state.currentUser ?
-        <div className={classes.userLogin}>
-          <h3>To get started on your first mission, login or sign up below!</h3>
-          <UserIndex />
-        </div> :
-        <>
-          <Link to="mission-control">Take me to mission control!</Link>
-        </>
-        } */}
         </div>
       </section>
     </PageContainer>

--- a/src/modules/views/Welcome.jsx
+++ b/src/modules/views/Welcome.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { makeStyles } from "@material-ui/core";
-import PageContainer from "../../ui/containers/PageContainer";
+import { PageContainer, TitleContainer } from "../../ui/containers";
 import { brainTraining, healthTraining, creativityTraining, basicTraining } from "../../assets/index";
 import theme from "../../ui/common/theme";
 import AppContext from "../App/AppContext";
@@ -107,7 +107,9 @@ const Welcome = () => {
   return (
     <PageContainer>
       <section className={classes.welcome}>
-        <h1>Welcome to KidDo!</h1>
+        <TitleContainer>
+          <h1>Welcome to KidDo!</h1>
+        </TitleContainer>
         <p>As a KidDo agent, it’s your job to complete missions that help you work towards being the best version of yourself. Mission Control is home to all the different missions you can do. Missions are built out of up to four tasks that can earn you points. Each task falls under one of these four categories:</p>
         <div className={classes.taskTypes}>
           <div className={classes.category}>

--- a/src/modules/views/Welcome.jsx
+++ b/src/modules/views/Welcome.jsx
@@ -4,10 +4,7 @@ import { PageContainer, TitleContainer } from "../../ui/containers";
 import { brainTraining, healthTraining, creativityTraining, basicTraining } from "../../assets/index";
 import theme from "../../ui/common/theme";
 import AppContext from "../App/AppContext";
-// import { Link } from "react-router-dom";
-// import UserIndex from "../login/UserIndex";
 import ModalWrapper from "../../ui/modal/ModalWrapper";
-
 
 const useStyles = makeStyles(() => ({
   welcome: {

--- a/src/modules/views/Welcome.jsx
+++ b/src/modules/views/Welcome.jsx
@@ -22,6 +22,9 @@ const useStyles = makeStyles(() => ({
   },
   category: {
     margin: "5%",
+    "& h2": {
+      fontSize: "26px"
+    }
   },
   categoryDesc: {
     fontSize: "0.8em",
@@ -113,7 +116,7 @@ const Welcome = () => {
         <p>As a KidDo agent, it’s your job to complete missions that help you work towards being the best version of yourself. Mission Control is home to all the different missions you can do. Missions are built out of up to four tasks that can earn you points. Each task falls under one of these four categories:</p>
         <div className={classes.taskTypes}>
           <div className={classes.category}>
-            <h3>Brain Training</h3>
+            <h2>Brain Training</h2>
 
             <ModalWrapper 
               id={categories.brain.id} 
@@ -122,14 +125,14 @@ const Welcome = () => {
               handleClose={handleClose}
               handleClickOpen={handleClickOpen}
               >
-              <div onClick={(e) => handleClickOpen(e)}>
+              <div aria-label="click to open brain training description" onClick={(e) => handleClickOpen(e)}>
                 <p className={classes.categoryDesc}>{categories.brain.description}</p>
               </div>
             </ModalWrapper>
           </div>
           
           <div className={classes.category}>
-            <h3>Creativity Training</h3>
+            <h2>Creativity Training</h2>
             <ModalWrapper 
               id={categories.creativity.id} 
               open={openCreativity} 
@@ -137,14 +140,14 @@ const Welcome = () => {
               handleClose={handleClose}
               handleClickOpen={handleClickOpen}
               >
-              <div onClick={(e) => handleClickOpen(e)}>
+              <div onClick={(e) => handleClickOpen(e)} aria-label="click to open creativity training description">
                 <p className={classes.categoryDesc}>{categories.creativity.description}</p>
               </div>
             </ModalWrapper>
           </div>
 
            <div className={classes.category}>
-            <h3>Health Training</h3>
+            <h2>Health Training</h2>
             <ModalWrapper 
               id={categories.health.id} 
               open={openHealth} 
@@ -152,14 +155,14 @@ const Welcome = () => {
               handleClose={handleClose}
               handleClickOpen={handleClickOpen}
               >
-              <div onClick={(e) => handleClickOpen(e)}>
+              <div onClick={(e) => handleClickOpen(e)} aria-label="click to open health training description">
                 <p className={classes.categoryDesc}>{categories.health.description}</p>
               </div>
             </ModalWrapper>
           </div>
             
           <div className={classes.category}>
-            <h3>Basic Training</h3>
+            <h2>Basic Training</h2>
             <ModalWrapper 
               id={categories.basic.id} 
               open={openBasic} 
@@ -167,7 +170,7 @@ const Welcome = () => {
               handleClose={handleClose}
               handleClickOpen={handleClickOpen}
               >
-              <div onClick={(e) => handleClickOpen(e)}>
+              <div onClick={(e) => handleClickOpen(e)} aria-label="click to open basic training description">
                 <p className={classes.categoryDesc}>{categories.basic.description}</p>
               </div>
             </ModalWrapper>


### PR DESCRIPTION
### What does this pull request do?
- Adds aria-labels, alt text to images, and descending headers to jsx elements
  - Web accessibility is now at least 91-100% for user and parent UI 
- Fixes helper text in Rewards view to reflect click to REDEEM (rather than "BUY" as before)
- Removes helper function in AgentDetails "determinePath" from useEffect so that it only fires on clicking the KidDo logo (this was unintentionally left behind in a previous PR)
- Adds state.redeemed to useEffect in AgentDetails; Now points are updated in sidebar on reward redemption
- Fixes useEffect() in AgentStats - now updates stats w/o refresh

### What files were changed?
- ParentView and corresponding files
- Welcome
- RewardStore
- AgentDetails

### Issues
#23 

### Next steps
- Check accessibility for mobile views

### Screenshots / Gifs

